### PR TITLE
Index module throws exception when es index can't be created

### DIFF
--- a/index/src/main/groovy/ncei/catalog/service/Service.groovy
+++ b/index/src/main/groovy/ncei/catalog/service/Service.groovy
@@ -24,7 +24,9 @@ class Service {
     this.restClient = restClient
     this.indexAdminService = indexAdminService
     if (!indexAdminService.indexExists(INDEX)) {
-      indexAdminService.createIndex(INDEX)
+      if(!indexAdminService.createIndex(INDEX)){
+        throw new Exception('Failed to create index.')
+      }
     }
   }
 

--- a/index/src/test/groovy/ncei/catalog/service/ServiceSpec.groovy
+++ b/index/src/test/groovy/ncei/catalog/service/ServiceSpec.groovy
@@ -16,7 +16,14 @@ class ServiceSpec extends Specification {
 
   RestClient mockRestClient = Mock(RestClient)
   IndexAdminService mockIndexAdminService = Mock(IndexAdminService)
-  Service service = Spy(Service, constructorArgs: [mockRestClient, mockIndexAdminService])
+  Service service
+
+  def setup() {
+    mockIndexAdminService.createIndex('search_index') >> true
+    service = new Service(mockRestClient, mockIndexAdminService)
+    service.restClient = mockRestClient
+    service.indexAdminService = mockIndexAdminService
+  }
 
   private buildMockResponse(Map payload, int statusCode, String method = 'GET') {
     def mockEntity = Mock(HttpEntity)
@@ -37,6 +44,16 @@ class ServiceSpec extends Specification {
     mockResponse.getHost() >> new HttpHost('testhost', 1234)
 
     return mockResponse
+  }
+
+  def 'failure to create index throws exception'(){
+    when:
+    IndexAdminService mockAdminService = Mock(IndexAdminService)
+    mockAdminService.createIndex('search_index') >> false
+    new Service(mockRestClient, mockAdminService)
+
+    then:
+    thrown Exception
   }
 
   def 'Insert: returns JSON API formatted information when created is #created'() {

--- a/index/src/test/groovy/ncei/catalog/service/ServiceSpec.groovy
+++ b/index/src/test/groovy/ncei/catalog/service/ServiceSpec.groovy
@@ -21,8 +21,6 @@ class ServiceSpec extends Specification {
   def setup() {
     mockIndexAdminService.createIndex('search_index') >> true
     service = new Service(mockRestClient, mockIndexAdminService)
-    service.restClient = mockRestClient
-    service.indexAdminService = mockIndexAdminService
   }
 
   private buildMockResponse(Map payload, int statusCode, String method = 'GET') {


### PR DESCRIPTION
When the index module fails to create the index with ES, it throws an exception that will prevent the app from coming up. Docker will try again and hopefully the index can be created at that point. 